### PR TITLE
Allow Node-RED catch node to handle produced errors

### DIFF
--- a/google-apis/google-apis.js
+++ b/google-apis/google-apis.js
@@ -122,7 +122,7 @@ module.exports = function(RED) {
                       shape: 'dot',
                       text: 'error'
                   });
-                  node.error(err);
+                  node.error(err, msg);
                   return;
               }
 
@@ -141,7 +141,7 @@ module.exports = function(RED) {
                           shape: 'dot',
                           text: 'error'
                       });
-                      node.error(err);
+                      node.error(err, msg);
                       return;
                   }
 


### PR DESCRIPTION
Thank you for this Google API node, it saved me a lot of time. I've found one thing that helps with error handling. You might want to include it so I've created this PR.

The original msg should be passed as a second argument to be able to be handled by the Catch node based on the documentation here - https://nodered.org/docs/user-guide/writing-functions#handling-errors